### PR TITLE
add teardown() method

### DIFF
--- a/format.js
+++ b/format.js
@@ -35,6 +35,11 @@ function setup(config, cb) {
   })
 }
 
+function teardown(cb) {
+  if (_keyring) _keyring.close(cb)
+  else cb()
+}
+
 function _isGroup(recp) {
   return _keyring.group.has(recp)
 }
@@ -142,6 +147,7 @@ module.exports = {
   // ssb-encryption-format API:
   name,
   setup,
+  teardown,
   encrypt,
   decrypt,
   // ssb-box2 specific APIs:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ssb-caps": "1.1.0",
     "ssb-db": "^20.4.0",
     "ssb-db2": "ssbc/ssb-db2#formats-split",
-    "ssb-encryption-format": "^2.1.0",
+    "ssb-encryption-format": "^2.2.0",
     "ssb-keys": "^8.4.0",
     "ssb-query": "^2.4.5",
     "ssb-tribes": "^2.7.4",


### PR DESCRIPTION
See https://github.com/ssbc/ssb-db2/pull/347#issuecomment-1190525041

Turns out that ssb-keyring already has a close() API, we just needed to use it. And I just added teardown to https://github.com/ssbc/ssb-encryption-format/commit/347f37e135c0ac55b5814adba90f16ab1f193e25 which is the tool that checks our repo.