### PR TITLE
dumb mistake with teardown() and leveldb.close()

### DIFF
--- a/format.js
+++ b/format.js
@@ -36,8 +36,9 @@ function setup(config, cb) {
 }
 
 function teardown(cb) {
-  if (_keyring) _keyring.close(cb)
-  else cb()
+  _keyringReady.onReady(() => {
+    _keyring.close(cb)
+  })
 }
 
 function _isGroup(recp) {


### PR DESCRIPTION
A dumb mistake. (If `_keyring` is not yet available, that doesn't mean it will never be available)