### PR TITLE
encryptionFormat module should not have state

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,22 @@ so with ssb-box2 you can use all the methods specified by ssb-encryption-format.
 
 ```js
 const ssbKeys = require('ssb-keys')
-const boxFormat = require('ssb-box2/format')
+const Box2Format = require('ssb-box2/format')
 
 const keys = ssbKeys.generate('ed25519', 'alice')
-boxFormat.setup({ keys }, () => {
-  boxFormat.setOwnDMKey(Buffer.alloc(32, 'abc'))
+const box2Format = Box2Format()
+
+box2Format.setup({ keys }, () => {
+  box2Format.setOwnDMKey(Buffer.alloc(32, 'abc'))
   const opts = { recps: [keys.id], keys, previous: null, author: keys.id }
 
   const plaintext = Buffer.from('hello')
   console.log(plaintext)
   // <Buffer 68 65 6c 6c 6f>
 
-  const ciphertext = boxFormat.encrypt(plaintext, opts)
+  const ciphertext = box2Format.encrypt(plaintext, opts)
 
-  const decrypted = boxFormat.decrypt(ciphertext, opts)
+  const decrypted = box2Format.decrypt(ciphertext, opts)
   console.log(decrypted)
   // <Buffer 68 65 6c 6c 6f>
 })

--- a/format.js
+++ b/format.js
@@ -12,147 +12,149 @@ const { SecretKey } = require('ssb-private-group-keys')
 const Keyring = require('ssb-keyring')
 const { ReadyGate } = require('./utils')
 
-const name = 'box2'
-
-let _keyring = null
-const _keyringReady = new ReadyGate()
-
 function reportError(err) {
   if (err) console.error(err)
 }
 
-function setup(config, cb) {
-  const keyringPath = path.join(
-    config.path || path.join(os.tmpdir(), '.ssb-keyring-' + Date.now()),
-    'keyring'
-  )
-  Keyring(keyringPath, (err, api) => {
-    if (err) return cb(err)
-    _keyring = api
-    _keyring.dm.addFromSSBKeys(config.keys)
-    _keyringReady.setReady()
-    cb()
-  })
-}
+const ATTEMPT1 = { maxAttempts: 1 }
+const ATTEMPT16 = { maxAttempts: 16 }
 
-function teardown(cb) {
-  _keyringReady.onReady(() => {
-    _keyring.close(cb)
-  })
-}
+function makeEncryptionFormat() {
+  let _keyring = null
+  const _keyringReady = new ReadyGate()
 
-function _isGroup(recp) {
-  return _keyring.group.has(recp)
-}
-
-function _isFeed(recp) {
-  return (
-    Ref.isFeed(recp) ||
-    Uri.isClassicFeedSSBURI(recp) ||
-    Uri.isBendyButtV1FeedSSBURI(recp) ||
-    Uri.isButtwooV1FeedSSBURI(recp)
-  )
-}
-
-function setOwnDMKey(key) {
-  _keyringReady.onReady(() => {
-    _keyring.self.set({ key }, reportError)
-  })
-}
-
-function addGroupKey(id, key) {
-  _keyringReady.onReady(() => {
-    _keyring.group.add(id, { key }, reportError)
-  })
-}
-
-function addKeypair(keypair) {
-  _keyringReady.onReady(() => {
-    _keyring.dm.addFromDMKeys(keypair, reportError)
-  })
-}
-
-function encrypt(plaintextBuf, opts) {
-  const recps = opts.recps
-  const authorId = opts.keys.id
-  const previousId = opts.previous
-
-  const validRecps = recps
-    .filter((recp) => typeof recp === 'string')
-    .filter((recp) => recp === authorId || _isGroup(recp) || _isFeed(recp))
-
-  if (validRecps.length === 0) {
-    // prettier-ignore
-    throw new Error(`no box2 keys found for recipients: ${recps}`)
-  }
-  if (validRecps.length > 16) {
-    // prettier-ignore
-    throw new Error(`private-group spec allows maximum 16 slots, but you've tried to use ${validRecps.length}`)
-  }
-  // FIXME: move these validations to ssb-groups
-  // if (validRecps.filter(isGroup).length === 0) {
-  //   // prettier-ignore
-  //   throw new Error(`no group keys found among recipients: ${recps}`)
-  // }
-  // if (!isGroup(validRecps[0])) {
-  //   // prettier-ignore
-  //   throw new Error(`first recipient must be a group, but you've tried to use ${validRecps[0]}`)
-  // }
-  const groupRecpsCount = validRecps.filter(_isGroup).length
-  if (groupRecpsCount > 1) {
-    // prettier-ignore
-    throw new Error(`private-group spec only supports one group recipient, but you've tried to use ${groupRecpsCount}`)
+  function setup(config, cb) {
+    const keyringPath = path.join(
+      config.path || path.join(os.tmpdir(), '.ssb-keyring-' + Date.now()),
+      'keyring'
+    )
+    Keyring(keyringPath, (err, api) => {
+      if (err) return cb(err)
+      _keyring = api
+      _keyring.dm.addFromSSBKeys(config.keys)
+      _keyringReady.setReady()
+      cb()
+    })
   }
 
-  const encryptionKeys = _keyring
-    .encryptionKeys(authorId, validRecps)
-    .filter((x) => x !== null)
+  function teardown(cb) {
+    _keyringReady.onReady(() => {
+      _keyring.close(cb)
+    })
+  }
 
-  const msgSymmKey = new SecretKey().toBuffer()
-  const authorIdBFE = BFE.encode(authorId)
-  const previousMsgIdBFE = BFE.encode(previousId)
+  function _isGroup(recp) {
+    return _keyring.group.has(recp)
+  }
 
-  const ciphertextBuf = box(
-    plaintextBuf,
-    authorIdBFE,
-    previousMsgIdBFE,
-    msgSymmKey,
-    encryptionKeys
-  )
+  function _isFeed(recp) {
+    return (
+      Ref.isFeed(recp) ||
+      Uri.isClassicFeedSSBURI(recp) ||
+      Uri.isBendyButtV1FeedSSBURI(recp) ||
+      Uri.isButtwooV1FeedSSBURI(recp)
+    )
+  }
 
-  return ciphertextBuf
+  function setOwnDMKey(key) {
+    _keyringReady.onReady(() => {
+      _keyring.self.set({ key }, reportError)
+    })
+  }
+
+  function addGroupKey(id, key) {
+    _keyringReady.onReady(() => {
+      _keyring.group.add(id, { key }, reportError)
+    })
+  }
+
+  function addKeypair(keypair) {
+    _keyringReady.onReady(() => {
+      _keyring.dm.addFromDMKeys(keypair, reportError)
+    })
+  }
+
+  function encrypt(plaintextBuf, opts) {
+    const recps = opts.recps
+    const authorId = opts.keys.id
+    const previousId = opts.previous
+
+    const validRecps = recps
+      .filter((recp) => typeof recp === 'string')
+      .filter((recp) => recp === authorId || _isGroup(recp) || _isFeed(recp))
+
+    if (validRecps.length === 0) {
+      // prettier-ignore
+      throw new Error(`no box2 keys found for recipients: ${recps}`)
+    }
+    if (validRecps.length > 16) {
+      // prettier-ignore
+      throw new Error(`private-group spec allows maximum 16 slots, but you've tried to use ${validRecps.length}`)
+    }
+    // FIXME: move these validations to ssb-groups
+    // if (validRecps.filter(isGroup).length === 0) {
+    //   // prettier-ignore
+    //   throw new Error(`no group keys found among recipients: ${recps}`)
+    // }
+    // if (!isGroup(validRecps[0])) {
+    //   // prettier-ignore
+    //   throw new Error(`first recipient must be a group, but you've tried to use ${validRecps[0]}`)
+    // }
+    const groupRecpsCount = validRecps.filter(_isGroup).length
+    if (groupRecpsCount > 1) {
+      // prettier-ignore
+      throw new Error(`private-group spec only supports one group recipient, but you've tried to use ${groupRecpsCount}`)
+    }
+
+    const encryptionKeys = _keyring
+      .encryptionKeys(authorId, validRecps)
+      .filter((x) => x !== null)
+
+    const msgSymmKey = new SecretKey().toBuffer()
+    const authorIdBFE = BFE.encode(authorId)
+    const previousMsgIdBFE = BFE.encode(previousId)
+
+    const ciphertextBuf = box(
+      plaintextBuf,
+      authorIdBFE,
+      previousMsgIdBFE,
+      msgSymmKey,
+      encryptionKeys
+    )
+
+    return ciphertextBuf
+  }
+
+  function decrypt(ciphertextBuf, opts) {
+    const authorId = opts.author
+    const authorBFE = BFE.encode(authorId)
+    const previousBFE = BFE.encode(opts.previous)
+
+    const { self, dm, group, poBox } = _keyring.decryptionKeys(authorId)
+
+    const unboxWith = unbox.bind(null, ciphertextBuf, authorBFE, previousBFE)
+
+    let plaintextBuf = null
+    if ((plaintextBuf = unboxWith(group, ATTEMPT1))) return plaintextBuf
+    if ((plaintextBuf = unboxWith(self, ATTEMPT16))) return plaintextBuf
+    if ((plaintextBuf = unboxWith(dm, ATTEMPT16))) return plaintextBuf
+    if ((plaintextBuf = unboxWith(poBox, ATTEMPT16))) return plaintextBuf
+
+    return null
+  }
+
+  return {
+    // ssb-encryption-format API:
+    name: 'box2',
+    setup,
+    teardown,
+    encrypt,
+    decrypt,
+    // ssb-box2 specific APIs:
+    setOwnDMKey,
+    addGroupKey,
+    addKeypair,
+  }
 }
 
-const attempt1 = { maxAttempts: 1 }
-const attempt16 = { maxAttempts: 16 }
-
-function decrypt(ciphertextBuf, opts) {
-  const authorId = opts.author
-  const authorBFE = BFE.encode(authorId)
-  const previousBFE = BFE.encode(opts.previous)
-
-  const { self, dm, group, poBox } = _keyring.decryptionKeys(authorId)
-
-  const unboxWith = unbox.bind(null, ciphertextBuf, authorBFE, previousBFE)
-
-  let plaintextBuf = null
-  if ((plaintextBuf = unboxWith(group, attempt1))) return plaintextBuf
-  if ((plaintextBuf = unboxWith(self, attempt16))) return plaintextBuf
-  if ((plaintextBuf = unboxWith(dm, attempt16))) return plaintextBuf
-  if ((plaintextBuf = unboxWith(poBox, attempt16))) return plaintextBuf
-
-  return null
-}
-
-module.exports = {
-  // ssb-encryption-format API:
-  name,
-  setup,
-  teardown,
-  encrypt,
-  decrypt,
-  // ssb-box2 specific APIs:
-  setOwnDMKey,
-  addGroupKey,
-  addKeypair,
-}
+module.exports = makeEncryptionFormat

--- a/index.js
+++ b/index.js
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const encryptionFormat = require('./format')
+const makeEncryptionFormat = require('./format')
 
 exports.name = 'box2'
 
 exports.init = function (ssb, config) {
+  const encryptionFormat = makeEncryptionFormat()
   if (ssb.db) ssb.db.installEncryptionFormat(encryptionFormat)
 
   return {

--- a/test/index.js
+++ b/test/index.js
@@ -7,9 +7,10 @@ const { check } = require('ssb-encryption-format')
 const ssbKeys = require('ssb-keys')
 const buttwoo = require('ssb-buttwoo/format')
 
-const box2 = require('../format')
+const Box2 = require('../format')
 
 test('passes ssb-encryption-format', (t) => {
+  const box2 = Box2()
   check(
     box2,
     () => {
@@ -29,6 +30,7 @@ test('passes ssb-encryption-format', (t) => {
 })
 
 test('decrypt as DM recipient from own encrypted DM', (t) => {
+  const box2 = Box2()
   const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
 
   box2.setup({ keys }, () => {
@@ -62,6 +64,7 @@ test('decrypt as DM recipient from own encrypted DM', (t) => {
 })
 
 test('decrypt as DM recipient from shared DM keys', (t) => {
+  const box2 = Box2()
   const keys1 = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
   const keys2 = ssbKeys.generate(null, 'bob', 'buttwoo-v1')
 
@@ -100,6 +103,7 @@ test('decrypt as DM recipient from shared DM keys', (t) => {
 })
 
 test('decrypt as group recipient', (t) => {
+  const box2 = Box2()
   const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
 
   box2.setup({ keys }, () => {
@@ -135,6 +139,7 @@ test('decrypt as group recipient', (t) => {
 })
 
 test('cannot decrypt own DM after we changed our own DM keys', (t) => {
+  const box2 = Box2()
   const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
 
   box2.setup({ keys }, () => {
@@ -168,6 +173,7 @@ test('cannot decrypt own DM after we changed our own DM keys', (t) => {
 })
 
 test('cannot encrypt to zero valid recipients', (t) => {
+  const box2 = Box2()
   const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
 
   box2.setup({ keys }, () => {
@@ -193,6 +199,7 @@ test('cannot encrypt to zero valid recipients', (t) => {
 })
 
 test('cannot encrypt to more than 16 recipients', (t) => {
+  const box2 = Box2()
   const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
 
   box2.setup({ keys }, () => {
@@ -236,6 +243,7 @@ test('cannot encrypt to more than 16 recipients', (t) => {
 })
 
 test('cannot encrypt to more than 1 group recipients', (t) => {
+  const box2 = Box2()
   const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
 
   box2.setup({ keys }, () => {


### PR DESCRIPTION
A smart mistake.

I was super confused why were ssb-db2 tests passing if I ran just one test file, but they were failing if I was running two or more test files. Turns out that our `ssb-box2` module was stateful (had state variables at the top-level of the file) so whenever you required it *twice* (and especially in parallel) the second `require` would override the state from the first `require`.

This was fixed by just wrapping the encryptionFormat in a "constructor".