### PR TITLE
Turn addGroupKey into addGroupInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ on the `sbot.box2` namespace:
 - `setOwnDMKey(key)`: Adds a `key` (a buffer) to the list of keys that can be
   used to encrypt messages to yourself. By specifying the direct message (DM)
   for yourself, you are free to supply that from any source. The key you provide
-  *will* be persisted locally. For direct messaging other feeds, a key is
+  _will_ be persisted locally. For direct messaging other feeds, a key is
   automatically derived.
-- `addGroupKey(groupId, groupKey)`: `groupId` must be a string and `groupKey`
-  must be a buffer. The key can then be used as a "recp" to encrypt messages to
-  the group. Note that the keys are not persisted in this module.
+- `addGroupInfo(groupId, groupInfo)`: `groupId` must be a string and `groupInfo` must be an object. `groupInfo` can have these keys:
+  - `key` must be a buffer. The key can then be used as a "recp" to encrypt messages to the group. Note that the keys are not persisted in this module.
+  - `scheme` _String_ - scheme of that encryption key (optional, there is only one option at the moment which we default to)
+  - `root` _MessageId_ the id of the `group/init` message
 - `listGroupIds(cb) => [groupIds]`: Lists all groupIds whose messages you're able to decrypt. Returns a promise if cb isn't provided.
 - `getGroupKeyInfo(id, cb) => { key, scheme }`: Gets the key and scheme for a group. Returns a promise if cb isn't provided.
 
@@ -101,6 +102,6 @@ box2Format.setup({ keys }, () => {
 })
 ```
 
-[SSB DB2]: https://github.com/ssb-ngi-pointer/ssb-db2/
+[ssb db2]: https://github.com/ssb-ngi-pointer/ssb-db2/
 [ssb-tribes]: https://github.com/ssbc/ssb-tribes/
 [ssb-keyring]: https://gitlab.com/ahau/lib/ssb-keyring/

--- a/format.js
+++ b/format.js
@@ -63,9 +63,10 @@ function makeEncryptionFormat() {
     })
   }
 
-  function addGroupKey(id, key) {
+  //TODO: update docs
+  function addGroupInfo(id, info) {
     _keyringReady.onReady(() => {
-      _keyring.group.add(id, { key }, reportError)
+      _keyring.group.add(id, info, reportError)
     })
   }
 
@@ -161,7 +162,7 @@ function makeEncryptionFormat() {
     decrypt,
     // ssb-box2 specific APIs:
     setOwnDMKey,
-    addGroupKey,
+    addGroupInfo,
     listGroupIds,
     addKeypair,
   }

--- a/format.js
+++ b/format.js
@@ -64,7 +64,6 @@ function makeEncryptionFormat() {
     })
   }
 
-  //TODO: update docs
   function addGroupInfo(id, info) {
     _keyringReady.onReady(() => {
       _keyring.group.add(id, info, reportError)
@@ -106,7 +105,9 @@ function makeEncryptionFormat() {
 
     const validGroupkeyRecps = recps.filter(
       (recp) =>
-        recp && Buffer.isBuffer(recp.key) && recp.scheme === keySchemes.private_group
+        recp &&
+        Buffer.isBuffer(recp.key) &&
+        recp.scheme === keySchemes.private_group
     )
 
     const validCount = validPkRecps.length + validGroupkeyRecps.length

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ exports.init = function (ssb, config) {
 
   return {
     setOwnDMKey: encryptionFormat.setOwnDMKey,
-    addGroupKey: encryptionFormat.addGroupKey,
+    addGroupInfo: encryptionFormat.addGroupInfo,
     listGroupIds: encryptionFormat.listGroupIds,
     addKeypair: encryptionFormat.addKeypair,
   }

--- a/test/index.js
+++ b/test/index.js
@@ -109,13 +109,12 @@ test('decrypt as group recipient', (t) => {
 
   box2.setup({ keys }, () => {
     const groupId = '%Lihvp+fMdt5CihjbOY6eZc0qCe0eKsrN2wfgXV2E3PM=.cloaked'
-    box2.addGroupKey(
-      groupId,
-      Buffer.from(
+    box2.addGroupInfo(groupId, {
+      key: Buffer.from(
         '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
         'hex'
-      )
-    )
+      ),
+    })
 
     const opts = {
       keys,
@@ -250,20 +249,18 @@ test('cannot encrypt to more than 1 group recipients', (t) => {
   box2.setup({ keys }, () => {
     const groupId1 = '%Aihvp+fMdt5CihjbOY6eZc0qCe0eKsrN2wfgXV2E3PM=.cloaked'
     const groupId2 = '%Bihvp+fMdt5CihjbOY6eZc0qCe0eKsrN2wfgXV2E3PM=.cloaked'
-    box2.addGroupKey(
-      groupId1,
-      Buffer.from(
+    box2.addGroupInfo(groupId1, {
+      key: Buffer.from(
         '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
         'hex'
-      )
-    )
-    box2.addGroupKey(
-      groupId2,
-      Buffer.from(
+      ),
+    })
+    box2.addGroupInfo(groupId2, {
+      key: Buffer.from(
         'ff720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
         'hex'
-      )
-    )
+      ),
+    })
 
     const opts = {
       keys,

--- a/test/tribes.js
+++ b/test/tribes.js
@@ -53,7 +53,7 @@ test('setup', (t) => {
       path: db1Dir,
     })
 
-    t.end()
+  t.end()
 })
 
 test('box2 message can be read with tribes', (t) => {
@@ -119,11 +119,11 @@ test('box2 group message can be read with tribes', (t) => {
     'hex'
   )
 
-  sbot.box2.addGroupKey(groupId, testkey)
+  sbot.box2.addGroupInfo(groupId, { key: testkey })
 
   const registerOpts = {
     key: testkey.toString('base64'),
-    root: '%MPB9vxHO0pvi2ve2wh6Do05ZrV7P6ZjUQ+IEYnzLfTs=.sha256'
+    root: '%MPB9vxHO0pvi2ve2wh6Do05ZrV7P6ZjUQ+IEYnzLfTs=.sha256',
   }
 
   db1Sbot.tribes.register(groupId, registerOpts, (err) => {
@@ -143,10 +143,13 @@ test('box2 group message can be read with tribes', (t) => {
           t.equal(msg.content.text, 'super secret')
 
           db1Sbot.add(privateMsg.value, (err) => {
-            db1Sbot.get({ id: privateMsg.key, private: true }, (err, db1Msg) => {
-              t.equal(db1Msg.content.text, 'super secret')
-              t.end()
-            })
+            db1Sbot.get(
+              { id: privateMsg.key, private: true },
+              (err, db1Msg) => {
+                t.equal(db1Msg.content.text, 'super secret')
+                t.end()
+              }
+            )
           })
         })
       })
@@ -217,17 +220,22 @@ test('we can decrypt a group message created with tribes', (t) => {
 })
 
 test('can list group ids', (t) => {
-  sbot.box2.listGroupIds().then(ids=> {
-    t.equal(ids.length, 1, 'lists the one group we are in')
+  sbot.box2
+    .listGroupIds()
+    .then((ids) => {
+      t.equal(ids.length, 1, 'lists the one group we are in')
 
-    t.true(ref.isCloakedMsg(ids[0]), 'lists a group id and not something else')
+      t.true(
+        ref.isCloakedMsg(ids[0]),
+        'lists a group id and not something else'
+      )
 
-    t.end()
-  })
+      t.end()
+    })
     .catch(t.error)
 })
 
-test('can get group info', async t => {
+test('can get group info', async (t) => {
   const info = await sbot.box2.getGroupKeyInfo(groupId)
 
   t.true(Buffer.isBuffer(info.key), 'key is a buffer')


### PR DESCRIPTION
Breaking change

To do https://github.com/ssbc/ssb-tribes2/pull/2 we need to be able to store and then get a group's root msg id. To store it we need to update addGroupKey to also accept a root to store.