### PR TITLE
Allow encrypt to accept keyinfo in recps

### DIFF
--- a/format.js
+++ b/format.js
@@ -105,7 +105,7 @@ function makeEncryptionFormat() {
 
     const validGroupkeyRecps = recps.filter(
       (recp) =>
-        Buffer.isBuffer(recp.key) && recp.scheme === keySchemes.private_group
+        recp && Buffer.isBuffer(recp.key) && recp.scheme === keySchemes.private_group
     )
 
     const validCount = validPkRecps.length + validGroupkeyRecps.length

--- a/format.js
+++ b/format.js
@@ -12,6 +12,7 @@ const { box, unbox } = require('envelope-js')
 const { SecretKey } = require('ssb-private-group-keys')
 const Keyring = require('ssb-keyring')
 const { ReadyGate } = require('./utils')
+const { keySchemes } = require('private-group-spec')
 
 function reportError(err) {
   if (err) console.error(err)
@@ -98,17 +99,24 @@ function makeEncryptionFormat() {
     const authorId = opts.keys.id
     const previousId = opts.previous
 
-    const validRecps = recps
+    const validPkRecps = recps
       .filter((recp) => typeof recp === 'string')
       .filter((recp) => recp === authorId || _isGroup(recp) || _isFeed(recp))
 
-    if (validRecps.length === 0) {
+    const validGroupkeyRecps = recps.filter(
+      (recp) =>
+        Buffer.isBuffer(recp.key) && recp.scheme === keySchemes.private_group
+    )
+
+    const validCount = validPkRecps.length + validGroupkeyRecps.length
+
+    if (validCount === 0) {
       // prettier-ignore
       throw new Error(`no box2 keys found for recipients: ${recps}`)
     }
-    if (validRecps.length > 16) {
+    if (validCount > 16) {
       // prettier-ignore
-      throw new Error(`private-group spec allows maximum 16 slots, but you've tried to use ${validRecps.length}`)
+      throw new Error(`private-group spec allows maximum 16 slots, but you've tried to use ${validCount}`)
     }
     // FIXME: move these validations to ssb-groups
     // if (validRecps.filter(isGroup).length === 0) {
@@ -119,15 +127,19 @@ function makeEncryptionFormat() {
     //   // prettier-ignore
     //   throw new Error(`first recipient must be a group, but you've tried to use ${validRecps[0]}`)
     // }
-    const groupRecpsCount = validRecps.filter(_isGroup).length
+    const groupRecpsCount =
+      validPkRecps.filter(_isGroup).length + validGroupkeyRecps.length
     if (groupRecpsCount > 1) {
       // prettier-ignore
       throw new Error(`private-group spec only supports one group recipient, but you've tried to use ${groupRecpsCount}`)
     }
 
-    const encryptionKeys = _keyring
-      .encryptionKeys(authorId, validRecps)
-      .filter((x) => x !== null)
+    const encryptionKeys = [
+      ..._keyring
+        .encryptionKeys(authorId, validPkRecps)
+        .filter((x) => x !== null),
+      ...validGroupkeyRecps,
+    ]
 
     const msgSymmKey = new SecretKey().toBuffer()
     const authorIdBFE = BFE.encode(authorId)

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ const test = require('tape')
 const { check } = require('ssb-encryption-format')
 const ssbKeys = require('ssb-keys')
 const buttwoo = require('ssb-buttwoo/format')
+const { keySchemes } = require('private-group-spec')
 
 const Box2 = require('../format')
 
@@ -280,6 +281,37 @@ test('cannot encrypt to more than 1 group recipients', (t) => {
     t.throws(() => {
       box2.encrypt(plaintext, opts)
     }, /private-group spec only supports one group recipient, but you've tried to use 2/)
+
+    t.end()
+  })
+})
+
+test('encrypt accepts keys as recps', (t) => {
+  const box2 = Box2()
+  const keys = ssbKeys.generate(null, 'alice', 'buttwoo-v1')
+
+  box2.setup({ keys }, () => {
+    const opts = {
+      keys,
+      content: { type: 'post', text: 'super secret' },
+      previous: null,
+      timestamp: 12345678900,
+      tag: buttwoo.tags.SSB_FEED,
+      hmacKey: null,
+      recps: [
+        {
+          key: Buffer.from(
+            '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+            'hex'
+          ),
+          scheme: keySchemes.private_group,
+        },
+      ],
+    }
+
+    const plaintext = buttwoo.toPlaintextBuffer(opts)
+
+    box2.encrypt(plaintext, opts)
 
     t.end()
   })


### PR DESCRIPTION
To allow us to not have to do manual encryption when creating a group in tribes2 https://github.com/ssbc/ssb-tribes2/pull/1#pullrequestreview-1112049170

We should also update the encrypt() spec a tad https://github.com/ssbc/ssb-encryption-format#encryptplaintext-opts