### PR TITLE
Add cb to addGroupInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ on the `sbot.box2` namespace:
   for yourself, you are free to supply that from any source. The key you provide
   _will_ be persisted locally. For direct messaging other feeds, a key is
   automatically derived.
-- `addGroupInfo(groupId, groupInfo)`: `groupId` must be a cloaked message Id or a uri encoded group and `groupInfo` must be an object. `groupInfo` can have these keys:
+- `addGroupInfo(groupId, groupInfo, cb)`: `groupId` must be a cloaked message Id or a uri encoded group and `groupInfo` must be an object. `groupInfo` can have these keys:
   - `key` must be a buffer. The key can then be used as a "recp" to encrypt messages to the group. Note that the keys are not persisted in this module.
   - `scheme` _String_ - scheme of that encryption key (optional, there is only one option at the moment which we default to)
   - `root` _MessageId_ the id of the `group/init` message

--- a/format.js
+++ b/format.js
@@ -118,9 +118,9 @@ function makeEncryptionFormat() {
     })
   }
 
-  function addGroupInfo(id, info) {
+  function addGroupInfo(id, info, cb) {
     keyringReady.onReady(() => {
-      keyring.group.add(id, info, reportError)
+      keyring.group.add(id, info, cb ? cb : reportError)
     })
   }
 


### PR DESCRIPTION
When adding a group key it would be nice to know when it was added to keyring so you can reindex afterwards. Before there was a race condition in tribes2 [here](https://github.com/ssbc/ssb-tribes2/blob/7622f23b1a98a3454f301e67e21eb2164dc84f34/index.js#L387) using this api.